### PR TITLE
Update markdownlint configuration to disable specific rules

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -9,5 +9,7 @@
         "line_length": 80,
         "code_blocks": false,
         "tables": false
-    }
+    },
+    "MD022": false,
+    "MD041": false
 }


### PR DESCRIPTION
Disable the MD022 and MD041 rules in the markdownlint configuration to allow for more flexibility in markdown formatting.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the markdownlint configuration to disable rules MD022 (Headings should be surrounded by blank lines) and MD041 (First line in file should be a top-level heading).

### Why are these changes being made?

These changes are made to accommodate our existing markdown documentation style, which doesn't always include blank lines around headings and doesn't require a top-level heading at the start of the file. This customization aligns the linting rules with our project's documentation standards and prevents unnecessary linting errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->